### PR TITLE
refactor (ci workflows): restore NPMJS to test-npm/npm matrix parameters, this time with _empty_ scope

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -49,13 +49,18 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPM_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -47,13 +47,18 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPM_TOKEN
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,13 +46,18 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPM_TOKEN
     needs: test-npm
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,18 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
     strategy:
       matrix:
-        source: [github]
+        source: [github, npmjs]
         include:
           - source: github
             registry-url: https://npm.pkg.github.com/
             scope: 'kagekirin'                        #must be lowercase, without '@'
             username: ${{ github.repository_owner }}  #not lowercase
             token: GITHUB_TOKEN
+          - source: npmjs
+            registry-url: https://registry.npmjs.org
+            scope: ''                                 #must be EMPTY
+            username: ${{ github.repository_owner }}  #not lowercase
+            token: NPM_TOKEN
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - id: npm-prepare-publish


### PR DESCRIPTION
- **refactor ('build-ci' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('build-pr' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('publish' workflow): restore parameters for 'npmjs' from 'test-npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  

- **refactor ('publish' workflow): restore parameters for 'npmjs' from 'npm' job matrix**
  big change to previous failed attempts: this time, the scope is left empty
  